### PR TITLE
Optimize gas usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Ownable Contract using Two-Step Transfer Pattern
 
 Contract module which provides a basic access controler mechanism,
 where there is an account (an owner) that can be granted exclusive
-access specific functions.
+access to specific functions.
 
 The contract owner is changeable through a two-step transfer pattern,
 in which a pending owner is assigned by the owner. Afterwards the
 pending owner can accept the contract's ownership.
 
 Note that the contract's owner can not be set to the zero address,
-i.e. the contract can not be withoyt ownership.
+i.e. the contract can not be without ownership.
 
 The contract's initial owner is the contract deployer.
 

--- a/src/Ownable.sol
+++ b/src/Ownable.sol
@@ -108,14 +108,13 @@ abstract contract Ownable {
     /// @notice Accept the contract's ownership as current pending owner.
     /// @dev Only callable by current pending owner.
     function acceptOwnership() external {
-		address pendingOwner_ = _pendingOwner;
-        if (msg.sender != pendingOwner_) {
+        if (msg.sender != _pendingOwner) {
             revert OnlyCallableByPendingOwner();
         }
 
-        emit NewOwner(owner, pendingOwner_);
+        emit NewOwner(owner, msg.sender);
 
-        owner = pendingOwner_;
+        owner = msg.sender;
         _pendingOwner = address(0);
     }
 }

--- a/src/Ownable.sol
+++ b/src/Ownable.sol
@@ -96,7 +96,7 @@ abstract contract Ownable {
     /// @dev Current owner as pending owner is invalid.
     /// @param pendingOwner_ The new pending owner.
     function setPendingOwner(address pendingOwner_) external onlyOwner {
-        if (pendingOwner_ == owner) {
+        if (pendingOwner_ == msg.sender) {
             revert InvalidPendingOwner();
         }
 
@@ -108,14 +108,14 @@ abstract contract Ownable {
     /// @notice Accept the contract's ownership as current pending owner.
     /// @dev Only callable by current pending owner.
     function acceptOwnership() external {
-        if (msg.sender != _pendingOwner) {
+		address pendingOwner_ = _pendingOwner;
+        if (msg.sender != pendingOwner_) {
             revert OnlyCallableByPendingOwner();
         }
 
-        emit NewOwner(owner, _pendingOwner);
+        emit NewOwner(owner, pendingOwner_);
 
-        owner = _pendingOwner;
+        owner = pendingOwner_;
         _pendingOwner = address(0);
     }
-
 }


### PR DESCRIPTION
Since it has been verified that the `_pendingOwner` is `msg.sender`, any further storage reads are redundant for `_pendingOwner`. And this is a better solution than caching `_pendingOwner`.

Additionally, some typos in `README.md` have been corrected.